### PR TITLE
Update ShareButton.php, correct call to javascript.void(), added `0` parameter to prevent syntaxerror

### DIFF
--- a/src/models/ShareButton.php
+++ b/src/models/ShareButton.php
@@ -20,7 +20,7 @@ class ShareButton extends Button
 
         if ($settings->useModalForShare) {
             $attributes['onclick'] = 'window.open(this.dataset.url, "ss_share_dialog", "width=626,height=436");';
-            $attributes['href'] = 'javascript:void();';
+            $attributes['href'] = 'javascript:void(0);';
             $attributes['data-url'] = $this->getProviderUrl();
         } else {
             $attributes['href'] = $this->getProviderUrl();


### PR DESCRIPTION
This previously caused a syntax error `Uncaught SyntaxError: Unexpected token ')'` in the console. Correct usage of void() is with a parameter of `0`